### PR TITLE
Adjust GLM fetch settings and enable experimental

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,12 +138,13 @@ message(STATUS "STB fetched")
 # https://github.com/g-truc/glm
 #
 message(STATUS "Fetching GLM")
-# set(GLM_TEST_ENABLE OFF CACHE BOOL "" FORCE)
-# set(GLM_BUILD_LIBRARY OFF CACHE BOOL "" FORCE)
+set(GLM_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(GLM_BUILD_INSTALL OFF CACHE BOOL "" FORCE)
+set(GLM_BUILD_LIBRARY OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
 	glm
 	GIT_REPOSITORY	https://github.com/g-truc/glm.git
-	GIT_TAG 	bf71a834948186f4097caa076cd2663c69a10e1e #refs/tags/1.0.1
+	GIT_TAG 	1.0.1
 )
 FetchContent_MakeAvailable(glm)
 message(STATUS "GLM fetched and made available")

--- a/src/RenderableMesh.cpp
+++ b/src/RenderableMesh.cpp
@@ -3,6 +3,7 @@
 
 #include "RenderableMesh.hpp"
 
+#define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/dual_quaternion.hpp>
 #include <assimp/version.h>
 


### PR DESCRIPTION
Configure GLM FetchContent in CMakeLists: set GLM_BUILD_TESTS, GLM_BUILD_INSTALL, and GLM_BUILD_LIBRARY to OFF and switch the GIT_TAG to '1.0.1' (was a specific commit hash). Add #define GLM_ENABLE_EXPERIMENTAL in src/RenderableMesh.cpp before including <glm/gtx/dual_quaternion.hpp> so the experimental dual-quaternion API can be used. Also normalize trailing newline at EOF.